### PR TITLE
Provide ability to pass app config to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ loader.loadStyleSheet(config.appCSS);
 This project provides modules for common tasks, such as reading and writing
 cookies; loading JavaScript and CSS; and queueing JavaScript calls from the
 host site until the core application resources arrive. [Learn more about the
-modules provided by this project](./docs/modules.md).
+modules provided by this project][modules].
 
 ### Including non-JS resources
 
@@ -306,9 +306,27 @@ build configuration for which it is true.**
 Read more about flags and the Webpack `DefinePlugin`
 [here](http://webpack.github.io/docs/list-of-plugins.html#defineplugin).
 
+#### Including configuration information
+
+To specify configuration data that should be available within the generated
+scout file, add an `appConfig` property to the config you provide to the
+generator (or the config for each grunt task).
+
+```
+appConfig : {
+  reviews : true,
+  comments : false,
+  customerName : 'atticus'
+}
+```
+
+See the [modules][modules] documentation for details on how to access this
+data via the `appConfig` module.
+
 [npm-url]: https://npmjs.org/package/scoutfile
 [npm-image]: https://badge.fury.io/js/scoutfile.svg
 [travis-url]: https://travis-ci.org/bazaarvoice/scoutfile
 [travis-image]: https://travis-ci.org/bazaarvoice/scoutfile.svg?branch=master
 [daviddm-url]: https://david-dm.org/bazaarvoice/scoutfile.svg?theme=shields.io
 [daviddm-image]: https://david-dm.org/bazaarvoice/scoutfile
+[modules]: ./docs/modules.md

--- a/README.md
+++ b/README.md
@@ -320,8 +320,9 @@ appConfig : {
 }
 ```
 
-See the [modules][modules] documentation for details on how to access this
-data via the `appConfig` module.
+The value you provide here should be an object that can be serialized using
+`JSON.stringify`. See the [modules][modules] documentation for details on how
+to access this data via the `appConfig` module.
 
 [npm-url]: https://npmjs.org/package/scoutfile
 [npm-image]: https://badge.fury.io/js/scoutfile.svg

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -79,6 +79,41 @@ APP.MyApp.render({ productId : 1 });
   original definition of the `configure` method. Queued items are processed
   synchronously, as they are not expected to have any DOM implications.
 
+## appConfig
+
+The appConfig module provides a way to include in-memory configuration
+information in your scout file. For example, you may build different scout
+files to support different products or customers, where product- or
+customer-specific configuration changes even though the fundamental contents
+of the scout file do not.
+
+In this case, you can provide this configuration information at build time
+using the `appConfig` option:
+
+```js
+scout.generate({
+  appModules: [
+    // ...
+  ],
+  appConfig: {
+    reviews: true,
+    comments: false,
+    customerName: 'atticus'
+  }
+});
+```
+
+You can then access the provided configuration using the `appConfig` module:
+
+
+```js
+var appConfig = require('scoutfile/lib/browser/appConfig');
+
+if (appConfig.reviews) {
+  // ...
+}
+```
+
 ## cookie
 
 The cookie module provides methods for interacting with browser cookies.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -105,7 +105,6 @@ scout.generate({
 
 You can then access the provided configuration using the `appConfig` module:
 
-
 ```js
 var appConfig = require('scoutfile/lib/browser/appConfig');
 

--- a/lib/browser/appConfig.js
+++ b/lib/browser/appConfig.js
@@ -1,0 +1,2 @@
+/* global SCOUTFILE_APP_CONFIG */
+module.exports = SCOUTFILE_APP_CONFIG;

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,8 @@ module.exports.generate = function generateScout(options, callback) {
   }
 
   options.flags = _.defaults(options.flags || {}, {
-    APP_NAMESPACE : JSON.stringify(options.namespace || DEFAULT_NAMESPACE)
+    APP_NAMESPACE : JSON.stringify(options.namespace || DEFAULT_NAMESPACE),
+    SCOUTFILE_APP_CONFIG : options.appConfig
   });
 
   webpackOptions.plugins.push(

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ module.exports.generate = function generateScout(options, callback) {
 
   options.flags = _.defaults(options.flags || {}, {
     APP_NAMESPACE : JSON.stringify(options.namespace || DEFAULT_NAMESPACE),
-    SCOUTFILE_APP_CONFIG : options.appConfig
+    SCOUTFILE_APP_CONFIG : JSON.stringify(options.appConfig)
   });
 
   webpackOptions.plugins.push(

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,9 +96,18 @@ module.exports.generate = function generateScout(options, callback) {
     webpackOptions.output.pathinfo = true;
   }
 
+  var appConfig;
+
+  try {
+    appConfig = JSON.stringify(options.appConfig || {});
+  }
+  catch (e) {
+    throw new Error('Cannot stringify appConfig value');
+  }
+
   options.flags = _.defaults(options.flags || {}, {
     APP_NAMESPACE : JSON.stringify(options.namespace || DEFAULT_NAMESPACE),
-    SCOUTFILE_APP_CONFIG : JSON.stringify(options.appConfig)
+    SCOUTFILE_APP_CONFIG : appConfig
   });
 
   webpackOptions.plugins.push(

--- a/test/fixtures/lib/index/app-config.js
+++ b/test/fixtures/lib/index/app-config.js
@@ -1,2 +1,1 @@
-/* global SCOUTFILE_APP_CONFIG */
-module.exports = SCOUTFILE_APP_CONFIG;
+module.exports = require('../../../../lib/browser/appConfig');

--- a/test/fixtures/lib/index/app-config.js
+++ b/test/fixtures/lib/index/app-config.js
@@ -1,0 +1,2 @@
+/* global SCOUTFILE_APP_CONFIG */
+module.exports = SCOUTFILE_APP_CONFIG;

--- a/test/unit/lib/index.js
+++ b/test/unit/lib/index.js
@@ -73,6 +73,26 @@ module.exports = {
               test.done();
             }, test.done);
           }
+        },
+        'options.appConfig': {
+          'enables config module': function (test) {
+            scout.generate({
+              appModules: [{
+                path: './test/fixtures/lib/index/app-config',
+                name: 'app-config'
+              }],
+              appConfig: {
+                myAppConfig: true
+              }
+            }).
+            then(function (src) {
+              test.ok(
+                src.indexOf('myAppConfig') > -1,
+                'app config should be included'
+              );
+              test.done();
+            });
+          }
         }
       }
     },


### PR DESCRIPTION
It's common that we need to include in our scout file in-memory configuration information that doesn't exist anywhere on the filesystem. This pull request allows us to do the following:

```js
scout.generate({
  // ...
  appConfig: {
    reviews: true
  }
});
```

Then, in our application's portion of the scout file, we can do:

```js
var appConfig = require('scoutfile/lib/appConfig);
```