### PR TITLE
Document is wrong in ie8 #7

### DIFF
--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -13,9 +13,6 @@
 'use strict';
 
 var doc = require('./global').document;
-var ie = require('./ie');
-
-var isOldIE = ie && ie < 9;
 
 var DEFAULT_TIMEOUT = 1000;
 
@@ -30,11 +27,6 @@ function isFileReady(readyState) {
     readyState === 'loaded' ||
     readyState === 'complete' ||
     readyState === 'uninitialized';
-}
-
-var nextId = 0;
-function getId() {
-  return 'scoutfileLoaderScript' + nextId++;
 }
 
 function validateArguments(url, options, callback) {
@@ -90,12 +82,6 @@ module.exports = {
       }
     }
 
-    if (isOldIE) {
-      // set up workaround to enforce script and callback ordering in old IE
-      script.event = 'onclick';
-      script.id = script.htmlFor = getId();
-    }
-
     function cleanUp(err) {
       done = true;
       clearTimeout(timeoutHandle);
@@ -115,14 +101,6 @@ module.exports = {
     script.onreadystatechange = script.onload = function () {
       if (done || !isFileReady(script.readyState)) {
         return;
-      }
-
-      if (isOldIE) {
-        try {
-          // ensure that the script is executed before the callback in old IE
-          script.onclick();
-        }
-        catch (e) {}
       }
 
       cleanUp();

--- a/test/fixtures/browser/lib.loader.document-is-wrong-in-ie8.js
+++ b/test/fixtures/browser/lib.loader.document-is-wrong-in-ie8.js
@@ -1,0 +1,6 @@
+/* global libLoaderTestCallback: false, document: false */
+'use strict';
+
+setTimeout(function () {
+  libLoaderTestCallback(document);
+}, 10);

--- a/test/unit/lib/browser/loader.js
+++ b/test/unit/lib/browser/loader.js
@@ -209,6 +209,18 @@ module.exports = {
         var timeout = setTimeout(function () {
           test.done(new Error('script load error timed out'));
         }, 1100);
+      },
+
+      '`document` has correct value in loaded script': function (test) {
+        global.libLoaderTestCallback = function (doc) {
+          test.strictEqual(
+            doc,
+            window.document,
+            '`document` should be === `window.document`');
+          test.done();
+        };
+
+        loader.loadScript('/lib.loader.document-is-wrong-in-ie8.js');
       }
     },
 


### PR DESCRIPTION
This PR removes the `onclick` hack for old IE, which was the root cause of #7. As a result, we no longer guarantee that the callback runs *immediately after* the loaded script is evaluated. The callback is still guaranteed to always run after the loaded script.