### PR TITLE
support for specifying attributes on loaded stylesheet

### DIFF
--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -157,6 +157,13 @@ module.exports = {
 
     var link = doc.createElement('link');
     var done = false;
+    var attr;
+
+    if (options.attributes) {
+      for (attr in options.attributes) {
+        link.setAttribute(attr, options.attributes[attr]);
+      }
+    }
 
     function cleanUp(err) {
       done = true;

--- a/test/unit/lib/browser/loader.js
+++ b/test/unit/lib/browser/loader.js
@@ -290,6 +290,19 @@ module.exports = {
               );
               test.done();
             }
+          },
+
+          'options.attributes': {
+            'sets attributes on the link tag': function (test) {
+              loader.loadStyleSheet('/lib.loader.loadstylesheet.css', {
+                attributes : {
+                  id : 'loaded-css'
+                }
+              }, function () {
+                test.ok(document.querySelector('#loaded-css'));
+                test.done();
+              });
+            }
           }
         },
 


### PR DESCRIPTION
We recently added support for specifying attributes on a loaded script; this provides the same support for loaded stylesheets.