### PR TITLE
UIA-7475: Adding support for an `injectionNode` option

### DIFF
--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -213,7 +213,8 @@ module.exports = {
         link.media = 'all';
       }, 0);
 
-      getFirstScript().parentNode.appendChild(link);
+      var injectionNode = options.injectionNode || getFirstScript().parentNode;
+      injectionNode.appendChild(link);
     }, 0);
   }
 };


### PR DESCRIPTION
This isn't fully complete, because it should have a test around it, but this is the gist of what I'd imagine.

This change should preserve the original functionality in full, but allow support to Firebird to pass in the document head as an injection node, minimizing risk to the other groups using scoutfile while allowing Firebird to preserve original functionality.