### PR TITLE
Tidy up Webpack options, and allow for creation of source maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ file for a client-side JavaScript application.
 To use this project, it is assumed you already have an environment running
 Node.
 
-## Roadmap & Issues
+## Roadmap and Issues
 
 See the [issues](//github.com/bazaarvoice/scoutfile/issues/) page for details on current development and future
 plans. If there is scout file functionality that your project needs and is not
@@ -328,7 +328,7 @@ to access this data via the `appConfig` module.
 
 To specify one or more "banners" to appear at the top of your file, add a
 banner property to the config you provide to the generator (or the config
-for each grunt task). 
+for each grunt task).
 
 ```
 banner : {
@@ -363,6 +363,76 @@ banner : [
     content : 'Copyright 2015 Bazaarvoice. All rights reserved'.
   }
 ];
+```
+
+#### Advanced Webpack configuration and source maps
+
+By passing in Webpack configuration options to the generator, you can override
+any of the default Webpack configuration that is constructed when generating a
+scout file. Note that this can absolutely break things, for example if you
+provide your own plugins array.
+
+A more common use case is to request a source map to be constructed:
+
+```
+var scout = require('scoutfile');
+scout.generate({
+  appModules: [
+    {
+      name: 'MyApp',
+      path: './app/scripts/scout/main.js'
+    }
+  ],
+
+  // Specify `pretty` to get un-uglified output.
+  pretty: true,
+
+  // Specify overridden Webpack options.
+  webpackOptions: {
+    // Create a source map file main.js.map in addition to the scout file.
+    devtool: 'source-map'
+  }
+}).then(function (sources) {
+  // When requesting a source map file in addition to a scout file, an array
+  // is returned.
+  console.log('Scout: ' + sources[0]);
+  console.log('Source map: ' + sources[1]);
+});
+```
+
+If using the grunt task, a `sourceMapDest` configuration property must be
+provided in addition to `dest` if the source map is generated as a separate
+file:
+
+```
+grunt.initConfig({
+  // ...
+  scoutfile: {
+    server : {
+      src : [
+        {
+          name : 'MyApp',
+          path : './app/scripts/scout/main.js'
+        }
+      ],
+      dest : '.tmp/scripts/scout.js',
+      sourceMapDest : '.tmp/scripts/scout.js.map'
+
+      // Override the default `APP` namespace
+      namespace: 'APPLICATION',
+
+      // Specify `pretty` to get un-uglified code
+      pretty : true,
+
+      // Specify overridden Webpack options.
+      webpackOptions: {
+        // Create a source map file that will be written to sourceMapDest.
+        devtool: 'source-map'
+      }
+    }
+  },
+  // ...
+});
 ```
 
 [npm-url]: https://npmjs.org/package/scoutfile

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var buildNumber = 0;
 var DEFAULT_NAMESPACE = 'APP';
 
 var overrides = {
+  appModules: [],
   entry: [
     path.join(
       __dirname, 'webpack-kernel-loader!'
@@ -28,13 +29,13 @@ var overrides = {
     filename: 'scout.js',
     sourcePrefix: ''
   },
+  plugins: [],
   resolve: {
     root: process.cwd()
   },
   resolveLoader: {
     root: path.resolve(__dirname, '../node_modules/')
   },
-  outputFileSystem: memfs,
   preLoaders: [
     {
       test: /kernel\.js/,
@@ -43,7 +44,7 @@ var overrides = {
   ]
 };
 
-var defaults = {
+var optionsDefaults = {
   appModules: [],
   webpackOptions: {}
 };
@@ -60,11 +61,13 @@ var webpackFailureTemplate = _.template(
  * asynchronously as a string.
  *
  * @param {object} options - Configuration for the built scout
+ * @param {object[]|object} options.banner - banner definitions
  * @param {object[]} options.appModules - commonjs application modules to bundle
  * @param {string} options.appModules[].name - unique module name
  * @param {string} options.appModules[].path - commonjs module path
+ * @param {string} options.webPackOptions - Overrides for Webpack options
  * @param {function} [callback] - node-style callback for the generated scout
- *          file source
+ *   file source
  *
  * @returns {BluebirdPromise} promise of the generated scout file source
  */
@@ -73,10 +76,8 @@ module.exports.generate = function generateScout(options, callback) {
     throw new Error('`options` is required');
   }
 
-  _.defaults(options, defaults);
-
+  _.defaults(options, optionsDefaults);
   var webpackOptions = _.cloneDeep(overrides);
-  _.merge(webpackOptions, defaults, options.webpackOptions);
 
   webpackOptions.scout = {
     appModules: options.appModules
@@ -85,8 +86,6 @@ module.exports.generate = function generateScout(options, callback) {
   // each build gets its own unique directory
   webpackOptions.output.path = '/build' + buildNumber;
   buildNumber++;
-
-  webpackOptions.plugins = options.webpackOptions.plugins || [];
 
   // uglify by default
   if (!options.pretty) {
@@ -130,8 +129,15 @@ module.exports.generate = function generateScout(options, callback) {
     new webpack.DefinePlugin(options.flags)
   );
 
+  // Any overrides for webpackOptions that are passed in to the task should be
+  // applied last of all. Yes, this can break things, especially if passing in
+  // a plugin array to stomp on the one constructed above, but it seems the most
+  // consistent behavior.
+  _.merge(webpackOptions, options.webpackOptions);
+
   // initialize webpack and use an in-memory filesystem
   var compiler = webpack(webpackOptions);
+
   compiler.outputFileSystem = memfs;
 
   var promise = new BluebirdPromise(function (resolve, reject) {
@@ -150,14 +156,46 @@ module.exports.generate = function generateScout(options, callback) {
             return reject(error);
           }
 
-          // look up the bundle, read it as a string, and delete the file
-          var bundlePath =
-            webpackOptions.output.path + '/' + webpackOptions.output.filename;
-          var src = memfs.readFileSync(bundlePath);
-          memfs.unlinkSync(bundlePath);
+          // Ok, so depending on options, we could have one or two files here:
+          // (a) the Javascript file, and (b) a source map file that will only
+          // be present if the user provided a value for webpackOptions.devtool.
+          var filenames = memfs.readdirSync(webpackOptions.output.path);
+
+          // Ensure this array is [javascriptFilename, sourceMapFilename] or
+          // [javascriptFilename].
+          filenames = _.sortBy(filenames, function (filename) {
+            return (filename === webpackOptions.output.filename) ? 0 : 1;
+          });
+
+          // Load in the code and delete the files.
+          var sources = _.map(filenames, function (filename) {
+            var filePath = path.join(webpackOptions.output.path, filename);
+            var fileContents = memfs.readFileSync(filePath).toString();
+
+            memfs.unlinkSync(filePath);
+            return fileContents;
+          });
+
+          // Clean up the directory.
           memfs.rmdirSync(webpackOptions.output.path);
 
-          resolve(src.toString());
+          // Send back the generated source (and source map if present).
+          //
+          // For backwards compatibility we only send an array if there is in
+          // fact a source map. Otherwise just return the source as a string.
+          //
+          // The pre-source-map-capable code returned only the source string,
+          // but Promises only allow one return argument so we can't just return
+          // two strings without using a structure like an array.
+          if (sources.length > 1) {
+            // Send an array.
+            resolve(sources);
+          }
+          else {
+            // Send the source string to maintain backwards compatibility with
+            // older versions.
+            resolve(sources[0]);
+          }
         }).
         catch(function (err) {
           reject(err);

--- a/test/fixtures/grunt-task/gruntfile.js
+++ b/test/fixtures/grunt-task/gruntfile.js
@@ -125,6 +125,33 @@ module.exports = function (grunt) {
             raw: true
           }
         }
+      },
+      sourceMap: {
+        src: [
+          {
+            name: 'app-one',
+            path: './app-one'
+          }
+        ],
+        pretty: true,
+        dest: '../../../test/scratch/sourcemap.js',
+        sourceMapDest: '../../../test/scratch/sourcemap.js.map',
+        webpackOptions: {
+          devtool: 'source-map'
+        }
+      },
+      sourceMapWithoutSourceMapDest: {
+        src: [
+          {
+            name: 'app-one',
+            path: './app-one'
+          }
+        ],
+        pretty: true,
+        dest: '../../../test/scratch/sourcemap.js',
+        webpackOptions: {
+          devtool: 'source-map'
+        }
       }
     }
   });

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -277,6 +277,69 @@ module.exports = {
           });
         }
       }
+    },
+    'source maps with webpackOptions and sourceMapDest': {
+      'source and source map are generated': function (test) {
+        grunt.util.spawn({
+          grunt: true,
+          args: [
+            '--gruntfile=' + TEST_GRUNTFILE,
+            '--no-color',
+            'scoutfile:sourceMap'
+          ]
+        }, function (err) {
+          if (err) {
+            return test.done(err);
+          }
+
+          var expectedSource = fs.readFileSync(
+            './test/fixtures/grunt-task/app-one.js',
+            { encoding: 'utf8' }
+          );
+          var actualSource = fs.readFileSync(
+            './test/scratch/sourcemap.js',
+            { encoding: 'utf8' }
+          );
+          var actualSourceMap = fs.readFileSync(
+            './test/scratch/sourcemap.js.map',
+            { encoding: 'utf8' }
+          );
+
+          test.ok(
+            actualSource.indexOf(expectedSource) >= 0,
+            'should contain app-one.js'
+          );
+          test.ok(
+            JSON.parse(actualSourceMap),
+            'JSON.parse works for the source map contents'
+          );
+          test.done();
+        });
+      },
+      'webpackOptions.devtools requires sourceMapDest': function (test) {
+        grunt.util.spawn({
+          grunt: true,
+          args: [
+            '--gruntfile=' + TEST_GRUNTFILE,
+            '--no-color',
+            'scoutfile:sourceMapWithoutSourceMapDest'
+          ]
+        }, function (err, result) {
+          test.equals(
+            result.code,
+            3,
+            'Should exit with `Task Error` exit code'
+          );
+          test.ok(
+            result.stdout.indexOf(
+              'sourceMapDest is not configured'
+            ) !== -1,
+            'Should complain about missing `sourceMapDest` option'
+          );
+
+          test.done();
+        });
+      }
     }
   }
 };

--- a/test/unit/lib/index.js
+++ b/test/unit/lib/index.js
@@ -11,7 +11,7 @@ module.exports = {
         'is required': function (test) {
           test.throws(function () {
             scout.generate();
-          }, /`options` is required/);
+          }, '`options` is required');
           test.done();
         },
         'options.src': {
@@ -170,6 +170,57 @@ module.exports = {
             }
           }
         }
+      }
+    },
+    sourceMaps: {
+      'webpackOptions.devtool=source-map returns array': function (test) {
+        scout.generate({
+          appModules: [{
+            path: './test/fixtures/lib/index/app-one',
+            name: 'app-one'
+          }],
+          pretty: true,
+          webpackOptions: {
+            devtool: 'source-map'
+          }
+        }).
+        then(function (srcArray) {
+          test.ok(_.isArray(srcArray), 'array is returned');
+          test.done();
+        });
+      },
+      'webpackOptions.devtool=source-map creates source map': function (test) {
+        var expectedOne =
+          fs.readFileSync('./test/fixtures/lib/index/app-one.js', {
+          encoding: 'utf8'
+        });
+
+        scout.generate({
+          appModules: [{
+            path: './test/fixtures/lib/index/app-one',
+            name: 'app-one'
+          }],
+          pretty: true,
+          webpackOptions: {
+            devtool: 'source-map'
+          }
+        }).
+        then(function (srcArray) {
+          test.ok(
+            srcArray[0].indexOf(expectedOne) > -1,
+            'scout should include app-one'
+          );
+          test.ok(
+            srcArray[0].indexOf('sourceMappingURL=') > -1,
+            'scout should include sourceMappingURL'
+          );
+          test.ok(
+            JSON.parse(srcArray[1]),
+            'JSON.parse can process the source map contents'
+          );
+
+          test.done();
+        });
       }
     },
     'returns a promise': {


### PR DESCRIPTION
Here I'm fixing up the generator code to more consistently accept Webpack options overrides via its configuration, and then enable source map creation. See the added docs below:

---

By passing in Webpack configuration options to the generator, you can override any of the default Webpack configuration that is constructed when generating a scout file. Note that this can absolutely break things, for example if you provide your own plugins array.

A more common use case is to request a source map to be constructed:

```
var scout = require('scoutfile');
scout.generate({
  appModules: [
    {
      name: 'MyApp',
      path: './app/scripts/scout/main.js'
    }
  ],

  // Specify `pretty` to get un-uglified output.
  pretty: true,

  // Specify overridden Webpack options.
  webpackOptions: {
    // Create a source map file main.js.map in addition to the scout file.
    devtool: 'source-map'
  }
}).then(function (sources) {
  // When requesting a source map file in addition to a scout file, an array
  // is returned.
  console.log('Scout: ' + sources[0]);
  console.log('Source map: ' + sources[1]);
});
```

If using the grunt task, a `sourceMapDest` configuration property must be provided in addition to `dest` if the source map is generated as a separate file:

```
grunt.initConfig({
  // ...
  scoutfile: {
    server : {
      src : [
        {
          name : 'MyApp',
          path : './app/scripts/scout/main.js'
        }
      ],
      dest : '.tmp/scripts/scout.js',
      sourceMapDest : '.tmp/scripts/scout.js.map'

      // Override the default `APP` namespace
      namespace: 'APPLICATION',

      // Specify `pretty` to get un-uglified code
      pretty : true,

      // Specify overridden Webpack options.
      webpackOptions: {
        // Create a source map file that will be written to sourceMapDest.
        devtool: 'source-map'
      }
    }
  },
  // ...
});
```