### PR TITLE
Add newline-after-var rule to eslint, tidy up code to match.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
       "afterColon": true
     }],
     "max-len": [2, 80, 4],
+    "newline-after-var": [2, "always"],
     "no-multiple-empty-lines": 2,
     "no-throw-literal": 2,
     "no-underscore-dangle": 0,

--- a/lib/browser/cookie.js
+++ b/lib/browser/cookie.js
@@ -5,6 +5,7 @@ var global = require('./global');
 module.exports = {
   create: function(name, value, days, domain, secure) {
     var date = new Date();
+
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
     var expires = days ? ';expires=' + date.toGMTString() : '';
 

--- a/lib/browser/ie.js
+++ b/lib/browser/ie.js
@@ -12,6 +12,7 @@ var doc = require('./global').document;
 module.exports = (function () {
   var ie = (function (v, div, undef) {
     var all = div.getElementsByTagName('i');
+
     while (
       div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->', all[0]
     ) {

--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -130,6 +130,7 @@ module.exports = {
       script.src = url;
 
       var firstScript = getFirstScript();
+
       firstScript.parentNode.insertBefore(script, firstScript);
     }, 0);
   },
@@ -233,6 +234,7 @@ module.exports = {
       }, 0);
 
       var injectionNode = options.injectionNode || getFirstScript().parentNode;
+
       try {
         injectionNode.appendChild(link);
       }

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -78,6 +78,7 @@ module.exports = {
             test.equals(result.code, 0, 'Should exit without errors');
 
             var expected = path.dirname(TEST_GRUNTFILE) + '/scout.js';
+
             test.ok(
               fs.existsSync(expected),
               'should output bundle as `' + expected + '`'
@@ -99,6 +100,7 @@ module.exports = {
             test.equals(result.code, 0, 'Should exit without errors');
 
             var expected = './test/scratch/src-entries-built-actual.js';
+
             test.ok(
               fs.existsSync(expected),
               'should output bundle as `' + expected + '`'

--- a/test/unit/lib/browser/application.js
+++ b/test/unit/lib/browser/application.js
@@ -69,6 +69,7 @@ module.exports = {
 
         'original render method always gets replaced': function(test) {
           var myApp = NS.MyApp;
+
           myApp.originalRender = myApp.render;
 
           var count = 0;
@@ -172,6 +173,7 @@ module.exports = {
 
         'original configure method always gets replaced': function(test) {
           var myApp = NS.MyApp;
+
           myApp.originalConfigure = myApp.configure;
 
           var count = 0;

--- a/test/unit/lib/browser/cookie.js
+++ b/test/unit/lib/browser/cookie.js
@@ -35,6 +35,7 @@ module.exports = {
 
       'reads a cookie': function (test) {
         var c = cookie.read('test read');
+
         test.equal(c, 'Hello World');
         test.done();
       }

--- a/test/unit/lib/browser/loader.js
+++ b/test/unit/lib/browser/loader.js
@@ -136,10 +136,12 @@ module.exports = {
           global.libLoaderTestCallback = function () {};
           test.done(new Error('script load timed out'));
         }, 1000);
+
       },
 
       'loads the script on a later turn of the event loop': function (test) {
         var later = false;
+
         setTimeout(function () {
           later = true;
         }, 0);
@@ -173,6 +175,7 @@ module.exports = {
         var timeout = setTimeout(function () {
           test.done(new Error('script load timed out'));
         }, 1000);
+
       },
 
       'executes callback after the script': function (test) {
@@ -190,6 +193,7 @@ module.exports = {
         var timeout = setTimeout(function () {
           test.done(new Error('script load timed out'));
         }, 1000);
+
       },
 
       'calls back on failure': function (test) {
@@ -210,6 +214,7 @@ module.exports = {
         var timeout = setTimeout(function () {
           test.done(new Error('script load error timed out'));
         }, 1100);
+
       },
 
       '`document` has correct value in loaded script': function (test) {
@@ -309,6 +314,7 @@ module.exports = {
           'options.injectionNode': {
             'defines injection point for link tag': function (test) {
               var container = doc.createElement('div');
+
               loader.loadStyleSheet('/lib.loader.loadstylesheet.css', {
                 injectionNode: container
               }, function () {
@@ -328,6 +334,7 @@ module.exports = {
             },
             'should throw if appending fails': function (test) {
               var container = doc.createElement('div');
+
               container.appendChild = function () {
                 throw new Error('Intentional sabotage!');
               };
@@ -418,6 +425,7 @@ module.exports = {
         var timeout = setTimeout(function () {
           test.done(new Error('stylesheet load error timed out'));
         }, 1100);
+
       }
     }
   }

--- a/test/unit/lib/index.js
+++ b/test/unit/lib/index.js
@@ -335,6 +335,7 @@ module.exports = {
           then(function (src) {
             test.doesNotThrow(function () {
                 var consoleError = console.error;
+
                 console.error = function () {};
                 /* eslint-disable no-new-func */
                 (new Function(src))();


### PR DESCRIPTION
Following on from comments in a previous PR, this adds the [newline-after-var](http://eslint.org/docs/rules/newline-after-var) rule to `.eslintrc` in order to enforce a newline after variable declarations, and tidies up the code to match.