### PR TITLE
Increase timeout 

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,14 @@ grunt.initConfig({
 });
 ```
 
+## Troubleshooting
+
+### loader timeout
+
+Understanding the loader module is critical to the usage of this repository. The default timeout is sufficient for common usage, but may not be large enough for environments where load times will be much slower than anticipated, such as slow mobile networks, dial-up connection, use of tunneling Selenium test services such as BrowserStack and Sauce Labs, and so forth. Older browsers such as IE8 may obfuscate timeout problems with other errors, making it difficult to debug such issues.
+
+If you experience any issues with application load timeouts, review the documentation on the [timeout option][timeout-option] and experiment with larger timeout values.
+
 [npm-url]: https://npmjs.org/package/scoutfile
 [npm-image]: https://badge.fury.io/js/scoutfile.svg
 [travis-url]: https://travis-ci.org/bazaarvoice/scoutfile
@@ -442,3 +450,4 @@ grunt.initConfig({
 [daviddm-url]: https://david-dm.org/bazaarvoice/scoutfile.svg?theme=shields.io
 [daviddm-image]: https://david-dm.org/bazaarvoice/scoutfile
 [modules]: ./docs/modules.md
+[timeout-option]: ./docs/modules.md#loader-timeout

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -222,7 +222,7 @@ old IE.
 - **attributes**: an object containing key/value pairs to be used as
 attributes on the created `<script>` element.
 - **timeout**: the time in milliseconds before the loading should be
-considered failed. Defaults to 1000ms.
+considered failed. Defaults to 10000ms.
 
 ### loadStyleSheet options
 
@@ -231,7 +231,25 @@ attributes on the created `<link>` element.
 - **injectionNode**: a DOM node into which the `<link>` element should be
 placed. The default insertion point is after the first `<script>` element on the page.
 - **timeout**: the time in milliseconds before the loading should be
-considered failed. Defaults to 1000ms.
+considered failed. Defaults to 10000ms.
+
+### loader timeout
+
+The loader module provides an extensible timeout that will invoke the provided callback with an error. In certain remote testing environments, the default timeout may not be sufficient for an initial page load. If you experience timeout errors when using the loader module you should experiment with raising this timeout using the provided `option.timeout`.
+
+```js
+var loader = require('scoutfile/lib/browser/loader');
+
+var options =  {
+  timeout : 30000
+}
+
+loader.loadScript('/scripts/main.js', options, function (err, cb) {
+  if (err) {
+    console.log('We may have timed out :(');
+  }
+});
+```
 
 ## namespace
 

--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -16,7 +16,7 @@
 var global = require('./global');
 var doc = global.document;
 
-var DEFAULT_TIMEOUT = 1000;
+var DEFAULT_TIMEOUT = 10000;
 
 function getFirstScript() {
   return doc.getElementsByTagName('script')[0];

--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -119,7 +119,15 @@ module.exports = {
       cleanUp(new Error('Error: could not load ' + url));
     };
 
-    var timeoutHandle = setTimeout(script.onerror, options.timeout);
+    // We should be able to catch most errors with onerror, but for browsers
+    // that don't support onerror we provide the below timeout cb
+    var timeoutHandle = setTimeout(function () {
+      if (done) {
+        return;
+      }
+
+      cleanUp(new Error('Error: script timeout ' + url));
+    }, options.timeout);
 
     // If a script is cached, IE may execute it immediately, which breaks
     // JavaScript's run-to-completion semantics. So, don't try to load the

--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -63,7 +63,7 @@ module.exports = {
    * @param {object} options.attributes - an object containing key/value pairs
    *  to be used as attributes on the created `script` element (optional)
    * @param {number} options.timeout - timeout in milliseconds (defaults to
-   *  1000ms)
+   *  10000ms)
    * @param {function} [callback] - node-style callback
    */
   loadScript: function (url, options, callback) {


### PR DESCRIPTION
I just experienced the most brutal hell of a few weeks trying to understand why an environment wouldn't load scripts for the first load of a page. The short answer is that 1 second is not sufficient to load scripts over a bandwidth constricted tunnel. At least not for the first time while the browser makes a connection to whatever server is hosting your script. 

In our case, we would hit the timeout which would try to then [use the loaded script](https://github.com/bazaarvoice/scoutfile/blob/master/lib/browser/loader.js#L98) which wasn't fully loaded yet, resulting in an error. My theory is that even though this results in a timeout, the browser (and intermediate servers) had already cached that resource request, so subsequent page loads were able to load the resource in under 1 second.

In the end, I referenced the [original script](https://github.com/SlexAxton/yepnope.js/blob/master/src/yepnope.js) we sourced for some of this code and found that they used a 10 second timeout, which I feel is adequate.

TL;DR - I wish to up the timeout to a nice 10 seconds. Also split the `script.onerror` callback and the timeout callback so future me has an easier time understanding which callback is at fault.