### PR TITLE
Fix issue with scout file injection on pages with MooTools or Prototype.

### DIFF
--- a/lib/browser/loader.js
+++ b/lib/browser/loader.js
@@ -178,7 +178,7 @@ module.exports = {
     // to `loadStyleSheet`.
     if (
       'injectionNode' in options &&
-      !(options.injectionNode instanceof global.Element)
+      !(options.injectionNode.nodeType && options.injectionNode.nodeType === 1)
     ) {
       throw new Error('`options.injectionNode` must be a DOM node');
     }


### PR DESCRIPTION
This is a fix I [should've contributed back long ago](https://github.com/savetheclocktower/firebird/commit/5744dc4d0459fb25faa0a1111ea075d563c3c27f), but forgot because I'm bad at computers.

This change opts for a duck-type of a DOM node instead of a direct `instanceof Element` check because certain frameworks overwrite the global `Element` variable. We could check for `instanceof HTMLElement` instead, but there's no need to run the risk of checking _any_ global when we're just trying to validate an argument.