### PR TITLE
Add .gitignore to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Ignore .gitignore so that we don't include it in the npm package.
+.gitignore


### PR DESCRIPTION
#43 

Ignore .gitignore in .npmignore.

This prevents .gitignore from being installed with the package, allowing users to check in updates to `node_modules/scoutfile/node_modules`.

To verify, init a temporary git repo, add `scoutfile#1.0.0` to your package.json and `npm install`. Then point the scoutfile dependency to to `scoutfile#2.0.0` and `npm install` again. You should see few changes as most of the updates in scoutfile/node_modules are ignored by .gitignore. Then, point to this commit, `sirugh/scoutfile#7937f4f` and `npm install` once more and you should see many more changes according to git.