### PR TITLE
Support some Webpack plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ banner : [
 By passing in Webpack configuration options to the generator, you can override
 any of the default Webpack configuration that is constructed when generating a
 scout file. Note that this can absolutely break things, for example if you
-provide your own plugins array.
+provide your own plugins array that includes plugins used by this library.
 
 A more common use case is to request a source map to be constructed:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,8 +146,9 @@ module.exports.generate = function generateScout(options, callback) {
             Object.getPrototypeOf(optionPlugin).constructor.name;
         }
         catch (e) {
-          throw new Error('Cannot verify that the plugin types included in ' +
-                          'options are allowed');
+          throw new Error(
+            'Cannot verify that the plugin types included in options are allowed' // eslint-disable-line max-len
+          );
         }
       });
     });
@@ -158,8 +159,10 @@ module.exports.generate = function generateScout(options, callback) {
 
   // Copy user-specified plugins to our Webpack options, then delete
   // them so the entire plugin list does not get overwritten.
-  Array.prototype.push.apply(webpackOptions.plugins,
-                             options.webpackOptions.plugins);
+  Array.prototype.push.apply(
+    webpackOptions.plugins,
+    options.webpackOptions.plugins
+  );
   delete options.webpackOptions.plugins;
 
   _.merge(webpackOptions, options.webpackOptions);

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,8 +131,31 @@ module.exports.generate = function generateScout(options, callback) {
 
   // Any overrides for webpackOptions that are passed in to the task should be
   // applied last of all. Yes, this can break things, especially if passing in
-  // a plugin array to stomp on the one constructed above, but it seems the most
-  // consistent behavior.
+  // a plugin array that overlaps with the one constructed above, but it seems
+  // the most consistent behavior.
+  var pluginAlreadyClaimed =
+    _.some(options.webpackOptions.plugins, function (optionPlugin) {
+      return _.some(webpackOptions.plugins, function (plugin) {
+        try {
+          return Object.getPrototypeOf(plugin).constructor.name ===
+            Object.getPrototypeOf(optionPlugin).constructor.name
+        }
+        catch (e) {
+          throw new Error('Cannot verify that the plugin types included in ' +
+                          'options are allowed')
+        }
+      });
+    });
+
+  if (pluginAlreadyClaimed) {
+    throw new Error('A plugin type included in options is already used')
+  }
+
+  Array.prototype.push.apply(webpackOptions.plugins,
+                             options.webpackOptions.plugins)
+
+  delete options.webpackOptions.plugins
+
   _.merge(webpackOptions, options.webpackOptions);
 
   // initialize webpack and use an in-memory filesystem

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,24 +137,30 @@ module.exports.generate = function generateScout(options, callback) {
     _.some(options.webpackOptions.plugins, function (optionPlugin) {
       return _.some(webpackOptions.plugins, function (plugin) {
         try {
+          // We have two plugins that are, presumably, instances of functions
+          // as on https://github.com/webpack/docs/wiki/how-to-write-a-plugin.
+          // If their prototypes have the same names, assume they are
+          // the same plugin. If we get an error and can't tell, assume the
+          // worst.
           return Object.getPrototypeOf(plugin).constructor.name ===
-            Object.getPrototypeOf(optionPlugin).constructor.name
+            Object.getPrototypeOf(optionPlugin).constructor.name;
         }
         catch (e) {
           throw new Error('Cannot verify that the plugin types included in ' +
-                          'options are allowed')
+                          'options are allowed');
         }
       });
     });
 
   if (pluginAlreadyClaimed) {
-    throw new Error('A plugin type included in options is already used')
+    throw new Error('A plugin type included in options is already used');
   }
 
+  // Copy user-specified plugins to our Webpack options, then delete
+  // them so the entire plugin list does not get overwritten.
   Array.prototype.push.apply(webpackOptions.plugins,
-                             options.webpackOptions.plugins)
-
-  delete options.webpackOptions.plugins
+                             options.webpackOptions.plugins);
+  delete options.webpackOptions.plugins;
 
   _.merge(webpackOptions, options.webpackOptions);
 


### PR DESCRIPTION
The scoutfile build uses three Webpack plugins. They are DefinePlugin, UglifyJsPlugin and BannerPlugin. While it definitely doesn't make sense to try to resolve the use of two UglifyJsPlugin's, there are [many others](https://webpack.github.io/docs/list-of-plugins.html) that apps could use without getting in scoutfile's way.

This change compares the two plugin lists, checks the prototype names for any matches, and errors out if there are any (or if they can't be determined).