### PR TITLE
Check for console before logging

### DIFF
--- a/lib/webpack-kernel-loader.js
+++ b/lib/webpack-kernel-loader.js
@@ -19,8 +19,17 @@ var requireWrapper =
       require('<%= path %>');
     }
     catch (e) {
-      console.error(
-        'Failed to load module `<%= name %>`', e.message);
+      // Log any exceptions and log, if possible, to the console.
+      var message = 'Failed to load module `<%= name %>`'
+
+      if (console) {
+        if (console.error) {
+          console.error(message,  e.message)
+        }
+        else if (console.log) {
+          console.log(message, e.message)
+        }
+      }
     }
   }.
   toString().

--- a/lib/webpack-kernel-loader.js
+++ b/lib/webpack-kernel-loader.js
@@ -11,24 +11,21 @@
 var _ = require('lodash');
 var pathResolve = require('path').resolve;
 
-// use Function.prototype.toString to obtain a template for requiring
-// application scout modules
+// NOTE: For compatibility with IE8/9 we check if console.error exists before
+//       logging. If we can't log the error, re-throw it. This is OK since we
+//       are already handling an error from the module require which means if
+//       an error is thrown, this app is going to break regardless.
 var requireWrapper =
   function () {
     try {
       require('<%= path %>');
     }
     catch (e) {
-      // Log any exceptions and log, if possible, to the console.
-      var message = 'Failed to load module `<%= name %>`'
-
-      if (console) {
-        if (console.error) {
-          console.error(message,  e.message)
-        }
-        else if (console.log) {
-          console.log(message, e.message)
-        }
+      if (console && console.error) {
+        console.error('Failed to load module `<%= name %>`',  e.message)
+      }
+      else {
+        throw e
       }
     }
   }.
@@ -36,6 +33,8 @@ var requireWrapper =
   replace(/^function \(\) {\n/, '').
   replace(/}$/, '');
 
+// Obtain a template for requiring app scout modules by using the above
+// wrapper's string representation.
 var appRequireTemplate = _.template(requireWrapper);
 
 /**

--- a/lib/webpack-kernel-loader.js
+++ b/lib/webpack-kernel-loader.js
@@ -14,7 +14,8 @@ var pathResolve = require('path').resolve;
 // NOTE: For compatibility with IE8/9 we check if console.error exists before
 //       logging. If we can't log the error, re-throw it. This is OK since we
 //       are already handling an error from the module require which means if
-//       an error is thrown, this app is going to break regardless.
+//       an error is thrown, this app is going to break regardless. Still, we
+//       throw in after a timeout to ensure execution of the rest of the code.
 var requireWrapper =
   function () {
     try {
@@ -25,7 +26,7 @@ var requireWrapper =
         console.error('Failed to load module `<%= name %>`',  e.message);
       }
       else {
-        throw e;
+        setTimeout(function () { throw e }, 0);
       }
     }
   }.

--- a/lib/webpack-kernel-loader.js
+++ b/lib/webpack-kernel-loader.js
@@ -22,10 +22,10 @@ var requireWrapper =
     }
     catch (e) {
       if (console && console.error) {
-        console.error('Failed to load module `<%= name %>`',  e.message)
+        console.error('Failed to load module `<%= name %>`',  e.message);
       }
       else {
-        throw e
+        throw e;
       }
     }
   }.


### PR DESCRIPTION
IE8/9 do not expose `window.console` unless the debugging tools are open. Yes, if we are in the catch block something has already gone wrong, but nevertheless, we should check if we have a `console` object before logging.

Technically we have two options here if we are in IE:

1. Log nothing, which simply hides the problem.
2. Re-throw, which may not be appropriate for third party script.

I opted for the first, but I'm open for discussion.
