### PR TITLE
JST-DEV: Adding BV scope for internal publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scoutfile",
+  "name": "@bv/scoutfile",
   "version": "4.0.0",
   "description": "Tools to generate a scout file for a client-side JS application",
   "main": "lib/index.js",


### PR DESCRIPTION
## Problem
In order to be able to publish this as a package for internal consumption, we'll need to add this scope tag.

## Solution

Added the scope tag to the package name

## Verification

Check that this change appears accurate with the instructions here: https://docs.npmjs.com/getting-started/scoped-packages