### PR TITLE
CCS-34126: update bv-ui-core dependency for CSP support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "2.0.1",
     "bluebird": "3.4.6",
-    "bv-ui-core": "0.12.0",
+    "bv-ui-core": "2.1.1",
     "css-loader": "0.25.0",
     "file-loader": "0.9.0",
     "handlebars": "4.0.5",


### PR DESCRIPTION
### Problem

Being a Firebird dependency, scoutfile contains CSP-incompatibly code in bv-ui-core package. 

### Solution
bv-ui-core has been updated in this [#PR33](https://github.com/bazaarvoice/bv-ui-core/pull/93) and a new version released. This would allow us to proceed with the changes needed for Content Security Support. (see epic CCS-34125 for details)
 
### Verification

Not exactly sure how to test this.
I run unit/node modules tests described on Contribution doc here:
https://github.com/bodrovphone/scoutfile/blob/master/CONTRIBUTING.md

![node_module_tests](https://user-images.githubusercontent.com/18177886/63259055-124db700-c286-11e9-80d3-3a0a7f48a5a6.png)
![nodeunit-browser](https://user-images.githubusercontent.com/18177886/63259066-15e13e00-c286-11e9-9c1e-a9f7849d0a5a.png)
![nodeunit](https://user-images.githubusercontent.com/18177886/63259074-18dc2e80-c286-11e9-92d6-d3189f2bfa1c.png)
![scout-unit-tests](https://user-images.githubusercontent.com/18177886/63259077-1bd71f00-c286-11e9-909a-8c34d6337bd7.png)


I also generated scoutfile locally. Got neither issues nor errors in the console.