### PR TITLE
update bv-ui-core dependency for csp support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "1.4.2",
     "bluebird": "2.9.34",
-    "bv-ui-core": "0.5.0",
+    "bv-ui-core": "0.5.1",
     "css-loader": "0.17.0",
     "file-loader": "0.8.4",
     "handlebars-loader": "1.1.1",


### PR DESCRIPTION
Problem

We migrated scoutfile dependency 2.0.0 -> 4.0.1 on Firebird repo to apply CSP-compatible fix.

old scoutfile(v2.0.0) has bv-ui-core v0.5.0 as its dependency
new scoutfile(v4.0.1) includes bv-ui-core v2.1.1

The problem here with this changes on bv-ui-core 0.11.1 which breaks Site Preview and mixed integration (Firebird + SWAT).

Solution

A solution would be to update bv-ui-core dependency with v0.5.1 and release scoutfile v2.0.1

See this [PR](https://github.com/bazaarvoice/bv-ui-core/pull/95) for details.